### PR TITLE
Close the quoted string in 'impl.sh' for 004

### DIFF
--- a/unix/004-rock-the-boat/impl.sh
+++ b/unix/004-rock-the-boat/impl.sh
@@ -3,4 +3,4 @@ set -e
 
 nc -k -l 8000&
 
-echo "When python -M SimpleHTTPServer works, you win!
+echo "When python -M SimpleHTTPServer works, you win!"


### PR DESCRIPTION
impl.sh (and consequently ./run) does not execute correctly due to an unclosed quote string. I have a religious objection to this bug.
